### PR TITLE
effective permission list

### DIFF
--- a/src/me/philipsnostrum/bungeepexbridge/BungeePexBridge.java
+++ b/src/me/philipsnostrum/bungeepexbridge/BungeePexBridge.java
@@ -204,7 +204,7 @@ public class BungeePexBridge extends Plugin {
     public boolean hasPermission(UUID uuid, String permission, boolean hasPermission) {
         permission = permission.toLowerCase();
         PermPlayer permPlayer = PermPlayer.getPlayer(uuid);
-        if (permPlayer != null && permPlayer.hasPermission("-" + permission))
+        if (permPlayer != null && permPlayer.getRevoked().contains(permission))
             return false;
         if (permPlayer != null && (permPlayer.hasPermission(permission) || permPlayer.hasPermission("*")))
             return true;
@@ -218,6 +218,22 @@ public class BungeePexBridge extends Plugin {
             if (group.getPermissions().contains(permission) || group.getPermissions().contains("*")) return true;
         }
         return false;
+    }
+    
+    public ArrayList<String> getEffectivePermissions(UUID uuid){
+    	ArrayList<String> permissions = new ArrayList<>();
+		ArrayList<String> revoked = new ArrayList<>();
+		
+		revoked.addAll(PermPlayer.getPlayer(uuid).getRevoked());
+		
+		PermGroup.getPlayerGroups(uuid).forEach(group -> permissions.addAll(group.getPermissions()));
+		PermGroup.getPlayerGroups(uuid).forEach(group -> revoked.addAll(group.getRevoked()));
+
+		permissions.removeIf(perm -> revoked.contains(perm));
+		
+		permissions.addAll(PermPlayer.getPlayer(uuid).getPermissions());
+    	
+    	return permissions;    	
     }
 }
 

--- a/src/me/philipsnostrum/bungeepexbridge/modules/PermGroup.java
+++ b/src/me/philipsnostrum/bungeepexbridge/modules/PermGroup.java
@@ -67,9 +67,6 @@ public class PermGroup implements Comparable<PermGroup> {
             this.permissions.remove(perm);
     }
 
-    public ArrayList<String> getRevoked() {
-        return revoked;
-    }
 
     private boolean isDefaultGroup() {
         return defaultGroup;
@@ -81,10 +78,6 @@ public class PermGroup implements Comparable<PermGroup> {
 
     public String getName() {
         return name;
-    }
-
-    public ArrayList<String> getPermissions() {
-        return permissions;
     }
 
     public ArrayList<String> getPlayers() {
@@ -109,5 +102,13 @@ public class PermGroup implements Comparable<PermGroup> {
     @Override
     public String toString() {
         return "name=" + name + " rank=" + rank;
+    }
+
+    public ArrayList<String> getPermissions() {
+        return permissions;
+    }
+
+    public ArrayList<String> getRevoked() {
+        return revoked;
     }
 }

--- a/src/me/philipsnostrum/bungeepexbridge/modules/PermPlayer.java
+++ b/src/me/philipsnostrum/bungeepexbridge/modules/PermPlayer.java
@@ -3,18 +3,24 @@ package me.philipsnostrum.bungeepexbridge.modules;
 import me.philipsnostrum.bungeepexbridge.BungeePexBridge;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 public class PermPlayer {
     private static ArrayList<PermPlayer> permPlayers = new ArrayList<>();
     private UUID uuid;
-    private List<String> permissions = new ArrayList<>();
+    private ArrayList<String> permissions = new ArrayList<>(), revoked = new ArrayList<>();
 
     public PermPlayer(UUID uuid) throws Exception {
         this.uuid = uuid;
-        for (String p : BungeePexBridge.getPerms().getPlayerPermissions(BungeePexBridge.get().getProxy().getPlayer(uuid)))
-            this.permissions.add(p.toLowerCase());
+
+        for (String permission : BungeePexBridge.getPerms().getPlayerPermissions(BungeePexBridge.get().getProxy().getPlayer(uuid))) {
+            String perm = permission.toLowerCase();
+            if (perm.startsWith("-"))
+                revoked.add(perm.replace("-", ""));
+            else this.permissions.add(perm);
+        }
+        for (String perm : revoked)
+            this.permissions.remove(perm);
     }
 
     public static ArrayList<PermPlayer> getPermPlayers() {
@@ -41,5 +47,13 @@ public class PermPlayer {
 
     public boolean hasPermission(String permission) {
         return permissions.contains(permission);
+    }
+    
+    public ArrayList<String> getPermissions() {
+        return permissions;
+    }
+    
+    public ArrayList<String> getRevoked() {
+        return revoked;
     }
 }


### PR DESCRIPTION
It would be nice if you could implement this in the next version of your plugin.

P.S.
I'm not quite sure if your hasPermission() is correct :?
If a group has a permission, which is removed by another group, it could happen that the group with the permission is before the other in the for-loop. Then the method will return true.